### PR TITLE
Incorrect time format for videos > 1000 secs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+﻿################################################################################
+# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
+################################################################################
+
+/.vs
+/FramerateConverter/obj
+/FramerateConverter/bin

--- a/FramerateConverter.sln
+++ b/FramerateConverter.sln
@@ -29,4 +29,10 @@ Global
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D21EB786-06A8-4D63-BF3A-723665F892DE}
 	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D21EB786-06A8-4D63-BF3A-723665F892DE}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D21EB786-06A8-4D63-BF3A-723665F892DE}
+	EndGlobalSection
 EndGlobal

--- a/FramerateConverter.sln
+++ b/FramerateConverter.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30626.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.645
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FreeVideoFPSConverter", "FramerateConverter\FreeVideoFPSConverter.csproj", "{E71186ED-5E92-4387-A26C-C0FF0A99C094}"
 EndProject
@@ -22,5 +22,11 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D21EB786-06A8-4D63-BF3A-723665F892DE}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D21EB786-06A8-4D63-BF3A-723665F892DE}
 	EndGlobalSection
 EndGlobal

--- a/FramerateConverter/MainWindow.xaml.cs
+++ b/FramerateConverter/MainWindow.xaml.cs
@@ -1243,13 +1243,13 @@ namespace FreeVideoFPSConverter
                     new XElement("VideoInfo", new XAttribute(XNamespace.Xmlns + "xsi", "http://www.w3.org/2001/XMLSchema-instance"), new XAttribute(XNamespace.Xmlns + "xsd", "http://www.w3.org/2001/XMLSchema"),
                         new XElement("InputFilename", SourceFilename),
                         new XElement("OutputFilename", TargetFilename),
-                        new XElement("Duration", OriginalDuration.ToString("N8", CultureInfo.InvariantCulture)),
+                        new XElement("Duration", OriginalDuration.ToString("F8", CultureInfo.InvariantCulture)),
                         new XElement("Width", width),
                         new XElement("Height", height),
-                        new XElement("Framerate", TargetFramerate.ToString("N8", CultureInfo.InvariantCulture)),
+                        new XElement("Framerate", TargetFramerate.ToString("F8", CultureInfo.InvariantCulture)),
                         new XElement("OriginalWidth", OriginalWidth),
                         new XElement("OriginalHeight", OriginalHeight),
-                        new XElement("OriginalFramerate", OriginalFramerate.ToString("N8", CultureInfo.InvariantCulture))));
+                        new XElement("OriginalFramerate", OriginalFramerate.ToString("F8", CultureInfo.InvariantCulture))));
 
                 doc.Save(xmlTargetFilename);
 


### PR DESCRIPTION
If a video with a length > 1000 secs is encoded with the Free Video FPS Converter, the format in the XML file uses invalid seperators. This PR fixes the problem and also adds a .gitignore file to the repository.